### PR TITLE
make data sources responsible for json conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 demo_project/demo_project/settings/local.py
 build/
 dist/
-
+.*

--- a/demo_project/requirements.txt
+++ b/demo_project/requirements.txt
@@ -3,7 +3,7 @@ Markdown==2.3.1
 Sphinx==1.2b1
 docutils==0.11
 numpy==1.7.1
-matplotlib==1.3.0
+matplotlib==1.3.1
 pymongo==2.5.1
 pyparsing==2.0.1
 python-dateutil==1.5

--- a/graphos/renderers/base.py
+++ b/graphos/renderers/base.py
@@ -1,6 +1,5 @@
-import json
-
 from django.template.loader import render_to_string
+
 from ..exceptions import GraphosException
 from ..utils import DEFAULT_HEIGHT, DEFAULT_WIDTH, get_random_string
 
@@ -21,7 +20,7 @@ class BaseChart(object):
         return self.data_source.get_data()
 
     def get_data_json(self):
-        return json.dumps(self.get_data())
+        return self.data_source.to_json(self.get_data())
 
     def get_options(self):
         options = self.options
@@ -30,7 +29,7 @@ class BaseChart(object):
         return options
 
     def get_options_json(self):
-        return json.dumps(self.get_options())
+        return self.data_source.to_json(self.get_options())
 
     def get_template(self):
         raise GraphosException("Not Implemented")

--- a/graphos/renderers/flot.py
+++ b/graphos/renderers/flot.py
@@ -1,5 +1,3 @@
-import json
-
 from .base import BaseChart
 from ..utils import get_default_options
 
@@ -28,7 +26,7 @@ class BaseFlotChart(BaseChart):
         return series_objects
 
     def get_series_objects_json(self):
-        return json.dumps(self.get_series_objects())
+        return self.data_source.to_json(self.get_series_objects())
 
     def get_options(self):
         options = get_default_options()
@@ -72,5 +70,6 @@ class ColumnChart(BaseFlotChart):
         options["horizontal"] = True
         return options
 
+
 class PieChart(BaseFlotChart):
-    pass  #TODO
+    pass  # TODO

--- a/graphos/renderers/gchart.py
+++ b/graphos/renderers/gchart.py
@@ -1,7 +1,5 @@
 from .base import BaseChart
 
-from django.template.loader import render_to_string
-
 
 class LineChart(BaseChart):
     def get_template(self):

--- a/graphos/renderers/highcharts.py
+++ b/graphos/renderers/highcharts.py
@@ -1,8 +1,4 @@
 from .base import BaseChart
-import json
-
-
-from django.template.loader import render_to_string
 
 
 class BaseHighCharts(BaseChart):
@@ -15,14 +11,13 @@ class BaseHighCharts(BaseChart):
         serieses = []
         for i, name in enumerate(series_names):
             serieses.append({"name": name, "data": column(data, i+1)[1:]})
-        return json.dumps(serieses)
+        return self.data_source.to_json(serieses)
 
     def get_categories(self):
-        return json.dumps(column(self.get_data(), 0)[1:])
+        return self.data_source.to_json(column(self.get_data(), 0)[1:])
 
     def get_x_axis_title(self):
         return self.get_data()[0][0]
-
 
 
 class LineChart(BaseHighCharts):

--- a/graphos/renderers/matplotlib_renderer.py
+++ b/graphos/renderers/matplotlib_renderer.py
@@ -1,11 +1,11 @@
 #Named such to not clash with matplotlib
-from .base import BaseChart
-
-from matplotlib.ticker import FormatStrFormatter
-
 import matplotlib.pyplot as plt
 import StringIO
 import base64
+
+from matplotlib.ticker import FormatStrFormatter
+
+from .base import BaseChart
 
 
 class BaseMatplotlibChart(BaseChart):

--- a/graphos/renderers/matplotlib_renderer.py
+++ b/graphos/renderers/matplotlib_renderer.py
@@ -1,8 +1,10 @@
-#Named such to not clash with matplotlib
-import matplotlib.pyplot as plt
 import StringIO
 import base64
 
+import matplotlib
+matplotlib.use('Agg')  # http://stackoverflow.com/a/4706614/202168
+#Named such to not clash with matplotlib
+import matplotlib.pyplot as plt
 from matplotlib.ticker import FormatStrFormatter
 
 from .base import BaseChart

--- a/graphos/renderers/morris.py
+++ b/graphos/renderers/morris.py
@@ -1,7 +1,5 @@
 from .base import BaseChart
-import json
 
-from django.template.loader import render_to_string
 
 class BaseMorrisChart(BaseChart):
     def get_data_json(self):
@@ -11,18 +9,16 @@ class BaseMorrisChart(BaseChart):
         for row in data_only:
             rows.append(dict(zip(header, row)))
 
-        return json.dumps(rows)
+        return self.data_source.to_json(rows)
 
     def get_category_key(self):
         return self.data_source.get_header()[0]
 
     def get_y_keys(self):
-        return json.dumps(self.data_source.get_header()[1:])
-
+        return self.data_source.to_json(self.data_source.get_header()[1:])
 
     def get_template(self):
         return "graphos/morris/chart.html"
-
 
 
 class LineChart(BaseMorrisChart):
@@ -34,10 +30,11 @@ class BarChart(BaseMorrisChart):
     def chart_type(self):
         return "Bar"
 
+
 class DonutChart(BaseMorrisChart):
     def get_data_json(self):
         data_only = self.get_data()[1:]
-        return json.dumps([{"label": el[0], "value": el[1]} for el in data_only])
+        return self.data_source.to_json([{"label": el[0], "value": el[1]} for el in data_only])
 
     def chart_type(self):
         return "Donut"

--- a/graphos/renderers/yui.py
+++ b/graphos/renderers/yui.py
@@ -1,7 +1,4 @@
 from .base import BaseChart
-from django.template.loader import render_to_string
-
-import json
 
 
 class BaseYuiChart(BaseChart):
@@ -12,7 +9,7 @@ class BaseYuiChart(BaseChart):
         for row in data_only:
             rows.append(dict(zip(header, row)))
 
-        return json.dumps(rows)
+        return self.data_source.to_json(rows)
 
     def get_category_key(self):
         return self.data_source.get_header()[0]
@@ -31,6 +28,7 @@ class BarChart(BaseYuiChart):
 class ColumnChart(BaseYuiChart):
     def get_template(self):
         return "graphos/yui/column_chart.html"
+
 
 class PieChart(BaseYuiChart):
     def get_template(self):

--- a/graphos/sources/base.py
+++ b/graphos/sources/base.py
@@ -1,5 +1,4 @@
 """Base Plot Data Handler"""
-
 from ..exceptions import GraphosException
 
 
@@ -19,3 +18,9 @@ class BaseDataSource(object):
         "Get the first column. Generally would be the x axis."
         "Subclasses should override this"
         raise GraphosException("Not Implemented")
+
+    def to_json(self, data):
+        "Serialize some data to json."
+        "Subclasses should override this"
+        raise GraphosException("Not Implemented")
+

--- a/graphos/sources/csv_file.py
+++ b/graphos/sources/csv_file.py
@@ -2,15 +2,13 @@ from .simple import SimpleDataSource
 
 import csv
 
+
 class CSVDataSource(SimpleDataSource):
     "A data source for CSV files"
     def __init__(self, csv_file, fields=None):
         """csv_file: A file like object which should be charted
         """
         reader = csv.reader(csv_file)
-        data =[row for row in reader]
+        data = [row for row in reader]
         self.data = data
         self.fields = fields
-
-    def get_data(self):
-        return self.data

--- a/graphos/sources/model.py
+++ b/graphos/sources/model.py
@@ -1,4 +1,7 @@
 """ Model Plot Data Handler"""
+import json
+from django.core.serializers.json import DjangoJSONEncoder
+
 from .simple import SimpleDataSource
 
 
@@ -23,3 +26,6 @@ class ModelDataSource(SimpleDataSource):
         for row in self.queryset:
             data.append(get_field_values(row, self.fields))
         return data
+
+    def to_json(self, data):
+        return json.dumps(data, cls=DjangoJSONEncoder)

--- a/graphos/sources/mongo.py
+++ b/graphos/sources/mongo.py
@@ -1,6 +1,6 @@
 """ Mongodb Plot Data Source """
 
-from .base import BaseDataSource
+from .simple import SimpleDataSource
 
 
 def get_row(doc, fields):
@@ -14,7 +14,7 @@ def get_row(doc, fields):
     return current_row
 
 
-class MongoDBDataSource(BaseDataSource):
+class MongoDBDataSource(SimpleDataSource):
     """ MongoDBDataSource """
 
     def __init__(self,
@@ -37,9 +37,3 @@ class MongoDBDataSource(BaseDataSource):
             doc_list.append(current_row)
         self._doc_list = doc_list
         return doc_list
-
-    def get_header(self):
-        return self.fields
-
-    def get_first_column(self):
-        return self.fields

--- a/graphos/sources/mongo.py
+++ b/graphos/sources/mongo.py
@@ -37,3 +37,7 @@ class MongoDBDataSource(SimpleDataSource):
             doc_list.append(current_row)
         self._doc_list = doc_list
         return doc_list
+
+    @property
+    def data(self):
+        return self.get_data()

--- a/graphos/sources/simple.py
+++ b/graphos/sources/simple.py
@@ -1,3 +1,5 @@
+import json
+
 from .base import BaseDataSource
 
 
@@ -14,3 +16,6 @@ class SimpleDataSource(BaseDataSource):
     def get_first_column(self):
         data_not_header = self.data[1:]
         return [el[0] for el in data_not_header]
+
+    def to_json(self, data):
+        return json.dumps(data)

--- a/graphos/tests.py
+++ b/graphos/tests.py
@@ -128,7 +128,10 @@ class TestMongoDBSource(TestCase):
         self.assertTrue(hasattr(self.data_source, 'get_first_column'))
         self.assertEqual(self.data, self.data_source.get_data())
         self.assertEqual(self.fields, self.data_source.get_header())
-        self.assertEqual(self.fields, self.data_source.get_first_column())
+        self.assertEqual(
+            [el[0] for el in self.data[1:]],
+            self.data_source.get_first_column()
+        )
 
     def tearDown(self):
         self.db.drop_collection(self.collection.name)


### PR DESCRIPTION
eg Django models need to use DjangoJSONEncoder

Only the data source knows how to correctly serialise to JSON for its objects, therefore the serialisation should happen in the data sources instead of the renderers