### PR TITLE
Callable fields, Morris preUnits, postUnits & ykeys, DjangoJSONEncoder

### DIFF
--- a/graphos/encoders.py
+++ b/graphos/encoders.py
@@ -1,0 +1,5 @@
+from django.core.serializers.json import DjangoJSONEncoder
+
+
+class GraphosEncoder(DjangoJSONEncoder):
+    pass

--- a/graphos/renderers/base.py
+++ b/graphos/renderers/base.py
@@ -3,19 +3,22 @@ import json
 from django.template.loader import render_to_string
 from ..exceptions import GraphosException
 from ..utils import DEFAULT_HEIGHT, DEFAULT_WIDTH, get_random_string
+from ..encoders import GraphosEncoder
 
 
 class BaseChart(object):
 
     def __init__(self, data_source, html_id=None,
                  width=None, height=None,
-                 options=None, *args, **kwargs):
+                 options=None, encoder=GraphosEncoder, 
+                 *args, **kwargs):
         self.data_source = data_source
         self.html_id = html_id or get_random_string()
         self.height = height or DEFAULT_HEIGHT
         self.width = width or DEFAULT_WIDTH
         self.options = options or {}
         self.header = data_source.get_header()
+        self.encoder = encoder
         self.context_data = kwargs
 
     def get_data(self):
@@ -31,7 +34,7 @@ class BaseChart(object):
         return options
 
     def get_options_json(self):
-        return json.dumps(self.get_options())
+        return json.dumps(self.get_options(), cls=self.encoder)
 
     def get_template(self):
         raise GraphosException("Not Implemented")

--- a/graphos/renderers/flot.py
+++ b/graphos/renderers/flot.py
@@ -28,7 +28,7 @@ class BaseFlotChart(BaseChart):
         return series_objects
 
     def get_series_objects_json(self):
-        return json.dumps(self.get_series_objects())
+        return json.dumps(self.get_series_objects(), cls=self.encoder)
 
     def get_options(self):
         options = get_default_options()

--- a/graphos/renderers/highcharts.py
+++ b/graphos/renderers/highcharts.py
@@ -15,10 +15,10 @@ class BaseHighCharts(BaseChart):
         serieses = []
         for i, name in enumerate(series_names):
             serieses.append({"name": name, "data": column(data, i+1)[1:]})
-        return json.dumps(serieses)
+        return json.dumps(serieses, cls=self.encoder)
 
     def get_categories(self):
-        return json.dumps(column(self.get_data(), 0)[1:])
+        return json.dumps(column(self.get_data(), 0)[1:], cls=self.encoder)
 
     def get_x_axis_title(self):
         return self.get_data()[0][0]

--- a/graphos/renderers/morris.py
+++ b/graphos/renderers/morris.py
@@ -17,7 +17,10 @@ class BaseMorrisChart(BaseChart):
         return self.data_source.get_header()[0]
 
     def get_y_keys(self):
-        return json.dumps(self.data_source.get_header()[1:], cls=self.encoder)
+        try:
+            return json.dumps(self.options['ykeys'], cls=self.encoder)
+        except KeyError:
+            return json.dumps(self.data_source.get_header()[1:], cls=self.encoder)
 
 
     def get_template(self):

--- a/graphos/renderers/morris.py
+++ b/graphos/renderers/morris.py
@@ -11,13 +11,13 @@ class BaseMorrisChart(BaseChart):
         for row in data_only:
             rows.append(dict(zip(header, row)))
 
-        return json.dumps(rows)
+        return json.dumps(rows, cls=self.encoder)
 
     def get_category_key(self):
         return self.data_source.get_header()[0]
 
     def get_y_keys(self):
-        return json.dumps(self.data_source.get_header()[1:])
+        return json.dumps(self.data_source.get_header()[1:], cls=self.encoder)
 
 
     def get_template(self):
@@ -37,7 +37,7 @@ class BarChart(BaseMorrisChart):
 class DonutChart(BaseMorrisChart):
     def get_data_json(self):
         data_only = self.get_data()[1:]
-        return json.dumps([{"label": el[0], "value": el[1]} for el in data_only])
+        return json.dumps([{"label": el[0], "value": el[1]} for el in data_only], cls=self.encoder)
 
     def chart_type(self):
         return "Donut"

--- a/graphos/renderers/yui.py
+++ b/graphos/renderers/yui.py
@@ -12,7 +12,7 @@ class BaseYuiChart(BaseChart):
         for row in data_only:
             rows.append(dict(zip(header, row)))
 
-        return json.dumps(rows)
+        return json.dumps(rows, cls=self.encoder)
 
     def get_category_key(self):
         return self.data_source.get_header()[0]

--- a/graphos/sources/model.py
+++ b/graphos/sources/model.py
@@ -5,7 +5,9 @@ from .simple import SimpleDataSource
 def get_field_values(row, fields):
     data = []
     for field in fields:
-        data.append(getattr(row, field))
+        value = getattr(row, field)
+        print value
+        data.append(value if not callable(value) else value())
     return data
 
 

--- a/graphos/sources/model.py
+++ b/graphos/sources/model.py
@@ -6,7 +6,6 @@ def get_field_values(row, fields):
     data = []
     for field in fields:
         value = getattr(row, field)
-        print value
         data.append(value if not callable(value) else value())
     return data
 

--- a/graphos/templates/graphos/morris/chart.html
+++ b/graphos/templates/graphos/morris/chart.html
@@ -12,7 +12,7 @@ new Morris.{{ chart.chart_type }}({
   ykeys: {{ chart.get_y_keys|safe }},
   // Labels for the ykeys -- will be displayed when you hover over the
   // chart.
-  labels: {{ chart.get_y_keys|safe }}
+  labels: {{ chart.get_y_keys|safe }},
   // post units
   postUnits: '{{ chart.get_options.postUnits|safe }}',
   preUnits: '{{ chart.get_options.preUnits|safe }}',

--- a/graphos/templates/graphos/morris/chart.html
+++ b/graphos/templates/graphos/morris/chart.html
@@ -13,5 +13,8 @@ new Morris.{{ chart.chart_type }}({
   // Labels for the ykeys -- will be displayed when you hover over the
   // chart.
   labels: {{ chart.get_y_keys|safe }}
+  // post units
+  postUnits: '{{ chart.get_options.postUnits }}',
+  preUnits: '{{ chart.get_options.preUnits }}',
 });
 </script>

--- a/graphos/templates/graphos/morris/chart.html
+++ b/graphos/templates/graphos/morris/chart.html
@@ -14,7 +14,7 @@ new Morris.{{ chart.chart_type }}({
   // chart.
   labels: {{ chart.get_y_keys|safe }}
   // post units
-  postUnits: '{{ chart.get_options.postUnits }}',
-  preUnits: '{{ chart.get_options.preUnits }}',
+  postUnits: '{{ chart.get_options.postUnits|safe }}',
+  preUnits: '{{ chart.get_options.preUnits|safe }}',
 });
 </script>


### PR DESCRIPTION
Maybe a lot of stuff in only one PR.

For my own purposes, I have added :
 - a GraphosEncoder (which inherits from DjangoJSONEncoder) to serialize Decimal fields ;
 - options for preUnits, postCommits and ykeys for Morris charts ;
 - the possibility to define callable fields as data fields for a data source.