### PR TITLE
use https instead of git demo project instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Graphos is a Django app to normalize data to create beautiful charts. It provide
 
 * Clone the project
 
-	git clone git@github.com:agiliq/django-graphos.git
+	git clone https://github.com/agiliq/django-graphos.git
 
 * Cd to demo directory
 


### PR DESCRIPTION
use https instead of git demo project `git clone` instructions.
the https method is better because it is not necessary to have previously set up the ssh keys. It makes life easier for novice users.