### PR TITLE
Removed mongo dependency from homepage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ Graphos is a Django app to normalize data to create beautiful charts. It provide
 
 	python manage.py migrate
 
-* Make sure mongo server is running(You should have mongodb properly setup for this)
-
-	mongod --dbpath ~/data/db
-
 * Run server
 
 	python manage.py runserver
 
 The installed demo app shows the various suported chart types.
+
+In case you want to use mongo data while charting, you must have mongodb properly setup and **pymongo** installed. Make sure mongo server is running.
+
+	mongod --dbpath ~/data/db
 
 
 ### Overview of Plot generation

--- a/demo_project/demo/templates/demo/home.html
+++ b/demo_project/demo/templates/demo/home.html
@@ -29,9 +29,6 @@ This is where magic happens.
 {{ g_chart.as_html }}
 
 
-<h2>Mongo Data with LineChart</h2>
-{{ m_chart.as_html }}
-
 <br />
 </div>
 {% endblock %}

--- a/demo_project/demo/utils.py
+++ b/demo_project/demo/utils.py
@@ -1,5 +1,3 @@
-import pymongo
-
 from .models import Account
 
 
@@ -8,6 +6,7 @@ DB_PORT = 27017
 
 
 def get_db(db_name):
+    import pymongo
     DB_HOST = ["localhost"]
     DB_PORT = 27017
     db = pymongo.Connection(DB_HOST, DB_PORT)[db_name]
@@ -15,6 +14,7 @@ def get_db(db_name):
 
 
 def get_mongo_cursor(db_name, collection_name, max_docs=100):
+    import pymongo
     db = pymongo.Connection(host=DB_HOST,
                             port=DB_PORT)[db_name]
     collection = db[collection_name]

--- a/demo_project/demo/views.py
+++ b/demo_project/demo/views.py
@@ -27,7 +27,6 @@ except ImportError:
 
 import markdown
 import datetime
-import pymongo
 from dateutil.parser import parse
 
 class MongoJson(FlotAsJson):
@@ -158,16 +157,20 @@ class Demo(TemplateView):
 def home(request):
     chart = flot.LineChart(SimpleDataSource(data=data), html_id="line_chart")
     g_chart = gchart.LineChart(SimpleDataSource(data=data))
+    context = {'chart': chart,
+               'g_chart': g_chart}
+    return render(request, 'demo/home.html', context)
+
+
+def other(request):
     cursor = get_mongo_cursor("graphos_mongo",
                               "zips",
                               max_docs=100)
     m_data = MongoDBDataSource(cursor=cursor, fields=['_id', 'pop'])
     m_chart = flot.LineChart(m_data)
-
-    context = {'chart': chart,
-               'g_chart': g_chart,
-               'm_chart': m_chart}
-    return render(request, 'demo/home.html', context)
+    context = {}
+    context['m_chart'] = m_chart
+    return render(request, 'demo/other.html', context)
 
 
 @cache_page(60*60*24)


### PR DESCRIPTION
To get running with demo project should be quick and easy and shouldn't
require mongo and pymongo installation. So removed MongoDataSource from
homepage.

We will demo MongoDataSource in some view other than homepage.

This way a user will be able to see gchart, morris, yui and all other
renderers without setting up mongo. And if he/she needs MongoDataSource,
then will setup mongo.