### PR TITLE
Added support for gchart's newer library loader

### DIFF
--- a/graphos/templates/graphos/gchart/base.html
+++ b/graphos/templates/graphos/gchart/base.html
@@ -1,6 +1,10 @@
 
 <script type="text/javascript">
-  google.setOnLoadCallback(drawChart{{ chart.get_html_id }});
+  if (typeof google.setOnLoadCallback !== 'undefined') {
+    google.setOnLoadCallback(drawChart{{ chart.get_html_id }});
+  } else {
+    google.charts.setOnLoadCallback(drawChart{{ chart.get_html_id }});
+  }
   function drawChart{{ chart.get_html_id }}() {
     {% block chart_specific_arraytodatatable %}
       var data = google.visualization.arrayToDataTable({{ chart.get_data_json|safe }});


### PR DESCRIPTION
After encountering several problems loading Google Charts (gchart) via Ajax I've added support for Google Chart's [preferred library loading method](https://developers.google.com/chart/interactive/docs/basic_load_libs).

As of Feburary 16, 2016:

> The version of Google Charts that remains available via the jsapi loader is no longer being updated consistently. The last update, for security purposes, was with a pre-release of v45. 

> Please use the new gstatic loader from now on [...]

[Source](https://developers.google.com/chart/interactive/docs/release_notes)

For compatibility reasons both methods are supported but you may decide to dismiss the old method in favor of the new one.


The following problems were solved with the proposed changes:

- unreliable rendering of charts loaded via Ajax

- [Parser-blocking warning](http://stackoverflow.com/a/39723541)
