### PR TITLE
Update html.html

### DIFF
--- a/graphos/templates/graphos/morris/html.html
+++ b/graphos/templates/graphos/morris/html.html
@@ -1,1 +1,1 @@
-<div id="{{ chart.get_html_id }}" style="width: {{ chart.width }}px; height: {{ chart.height }}px;"></div>
+<div id="{{ chart.get_html_id }}" class="{{ chart.get_html_class }}" style="position: {{ chart.position }}; width: {{ chart.width }}; height: {{ chart.height }};"></div>


### PR DESCRIPTION
Addition commit of adding the html_class and position attribute. Another change is the removal of "px", due to the fact that browsers are already bringing this unit by default when we only enter the value and allow greater autonomy, because you can specify in which unit you want to work, such as: px, cm, inherit,% (% as raised in Issue # 124 - Setting Chart size to width of page?).